### PR TITLE
Bump version to 0.1.1 and fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-version, release]
     if: always() && needs.release.result == 'success'
-    permissions: none
     steps:
       - name: Release Success Notification
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "importy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A CLI tool for analyzing JavaScript/TypeScript imports from libraries",
   "homepage": "https://github.com/tvshevchuk/Importy#readme",
   "bugs": {


### PR DESCRIPTION
Remove restrictive permissions from notify job to allow proper execution of release success notifications.