### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-version, release, publish]
     if: always() && needs.release.result == 'success' && needs.publish.result == 'success'
+    permissions: {}
     steps:
       - name: Release Success Notification
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/tvshevchuk/Importy/security/code-scanning/18](https://github.com/tvshevchuk/Importy/security/code-scanning/18)

To fix this, explicitly set minimal GITHUB_TOKEN permissions where they are currently implicit. The CodeQL warning is on the `notify` job, which performs only shell `echo` commands and does not interact with the repository or GitHub APIs, so it does not require any token permissions. The best fix that preserves existing functionality is to add a `permissions: {}` (or `permissions: read-all`) block to that job to ensure that GITHUB_TOKEN is either fully disabled or at least restricted. Since no token usage is present, `permissions: {}` is appropriate and safest.

Concretely: in `.github/workflows/release.yml`, under the `notify` job (lines 119–123), add a `permissions: {}` key at the same indentation level as `runs-on`, `needs`, and `if`. No other jobs need changes for this specific finding, because `release` and `publish` already declare permissions and `check-version` only needs default read access; the CodeQL report is specifically about `notify`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
